### PR TITLE
Testing incremental

### DIFF
--- a/dbt/include/global_project/macros/adapters/vertica.sql
+++ b/dbt/include/global_project/macros/adapters/vertica.sql
@@ -1,0 +1,19 @@
+-- NH: for vertica temporary tables by default follow on commit delete semantics.
+--     One needs to expressly specify on commit preserve rows.
+-- NH: Also when using select the proper syntax is select into temporary table
+{% macro vertica__create_table_as(temporary, relation, sql) -%}
+  {% if temporary %}
+    -- This is using vertica.sql in adapters in temporary mode;
+    select * into temporary table  {{ relation.include(schema=(True)) }} on commit preserve rows
+    from (
+      {{ sql }}
+    ) v;
+  {% else %}
+    -- This is from vertica.sql adapter and not using temporary: {{ relation }}
+    create table
+      {{ relation.include(schema=(True)) }}
+    as (
+      {{ sql }}
+    );
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/global_project/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/global_project/macros/materializations/incremental/incremental.sql
@@ -1,7 +1,3 @@
-{% macro dbt__test_output(value) -%}
-  insert into testing.testoutput (whn, statement) VALUES (now(), '{{ value }}' );
-{%- endmacro %}
-
 {% macro dbt__incremental_delete(target_relation, tmp_relation) -%}
 
   {%- set unique_key = config.require('unique_key') -%}
@@ -82,14 +78,6 @@
                                            to_schema=schema,
                                            to_table=identifier) }}
 
-     -- Check the unique_key and sql_where:
-     {%- call statement() -%}
-        {{ dbt__test_output("A: sql_where: {}".format(sql_where)) }}
-     {%- endcall -%}
-     {%- call statement() -%}
-        {{ dbt__test_output("B: unique_key: {}".format(unique_key)) }}
-     {%- endcall -%}
-
      {%- call statement('main') -%}
        {% set dest_columns = adapter.get_columns_in_table(schema, identifier) %}
        {% set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') %}
@@ -115,6 +103,7 @@
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-
+  -- NH: for vertica global temporary are not cleaned up automatically
+  {{ drop_relation_if_exists(tmp_relation) }}
 
 {%- endmaterialization %}


### PR DESCRIPTION
Current working version of the incremental. 

Looks like everything is updating correctly now. 

Some testing:
```
-- First run
dbadmin=> select * from testing.test_incremental  ;
 f1 | delta | updated_on |              now
----+-------+------------+-------------------------------
  1 |     4 | 2019-01-01 | 2019-02-14 19:47:09.841685+00
  2 |     3 | 2019-01-01 | 2019-02-14 19:47:09.841685+00
  3 |     5 | 2019-01-01 | 2019-02-14 19:47:09.841685+00

-- Second run with deltas added to source table:
 f1 | delta | updated_on |              now
----+-------+------------+-------------------------------
  3 |     5 | 2019-01-01 | 2019-02-14 19:47:54.460003+00
  1 |     6 | 2019-01-03 | 2019-02-14 19:48:00.404837+00
  2 |     7 | 2019-01-03 | 2019-02-14 19:48:00.404837+00
  4 |     8 | 2019-01-03 | 2019-02-14 19:48:00.404837+00

-- Third run with another round of deltas:
 f1 | delta | updated_on |              now
----+-------+------------+-------------------------------
  1 |     6 | 2019-01-03 | 2019-02-14 19:48:00.404837+00
  2 |     7 | 2019-01-03 | 2019-02-14 19:48:00.404837+00
  4 |     8 | 2019-01-03 | 2019-02-14 19:48:00.404837+00
  3 |     9 | 2019-01-04 | 2019-02-14 19:48:10.642081+00
  5 |    10 | 2019-01-04 | 2019-02-14 19:48:10.642081+00
  6 |    11 | 2019-01-04 | 2019-02-14 19:48:10.642081+00
```

In the second run there were two updated rows, and 1 new row. You can see the updated_on date and now timestamp for f1=3 does not change. 

In the third run, there were two new rows and one update. You can see the updated_on date and now timestamp for f1=(1,2,4) does not change, but the records where f1=(3,5,6) are updated.