### PR TITLE
Updated DBT Vertica connector and contracts for SSL

### DIFF
--- a/dbt/adapters/vertica/impl.py
+++ b/dbt/adapters/vertica/impl.py
@@ -69,10 +69,14 @@ class VerticaAdapter(dbt.adapters.default.DefaultAdapter):
         kwargs = {}
         keepalives_idle = credentials.get('keepalives_idle',
                                           cls.DEFAULT_TCP_KEEPALIVE)
+        ssl_enabled = credentials.get('ssl', False)
         # we don't want to pass 0 along to connect() as vertica will try to
         # call an invalid setsockopt() call (contrary to the docs).
         if keepalives_idle:
             kwargs['keepalives_idle'] = keepalives_idle
+        if ssl_enabled:
+            print('SSL IS ENABLED...')
+            kwargs['ssl'] = 'enabled'
 
         try:
             handle = vertica_python.connect(
@@ -168,7 +172,7 @@ class VerticaAdapter(dbt.adapters.default.DefaultAdapter):
 
     def _list_relations(self, schema, model_name=None):
         sql = """
-        select table_name as name, schema_name as schema, lower(table_type) as type 
+        select table_name as name, schema_name as schema, lower(table_type) as type
         from v_catalog.all_tables
         where table_type in ('TABLE', 'VIEW') and
         schema_name ilike '{schema}'
@@ -216,7 +220,7 @@ class VerticaAdapter(dbt.adapters.default.DefaultAdapter):
         but should not affect us as dbt does work across databases
         and we do not expect that convertion to ever be called
         '''
-        
+
         return "long varchar"
 
     @classmethod

--- a/dbt/contracts/connection.py
+++ b/dbt/contracts/connection.py
@@ -30,6 +30,9 @@ VERTICA_CREDENTIALS_CONTRACT = {
         'keepalives_idle': {
             'type': 'integer',
         },
+        'ssl': {
+            'type': 'boolean',
+        },
     },
     'required': ['dbname', 'host', 'user', 'pass', 'port', 'schema'],
 }

--- a/dbt/contracts/project.py
+++ b/dbt/contracts/project.py
@@ -3,7 +3,7 @@ from dbt.logger import GLOBAL_LOGGER as logger  # noqa
 from dbt.utils import deep_merge
 from dbt.contracts.connection import POSTGRES_CREDENTIALS_CONTRACT, \
     REDSHIFT_CREDENTIALS_CONTRACT, SNOWFLAKE_CREDENTIALS_CONTRACT, \
-    BIGQUERY_CREDENTIALS_CONTRACT
+    BIGQUERY_CREDENTIALS_CONTRACT, VERTICA_CREDENTIALS_CONTRACT
 
 # TODO: add description fields.
 ARCHIVE_TABLE_CONFIG_CONTRACT = {
@@ -318,6 +318,7 @@ PROFILE_INFO_CONTRACT = {
                 REDSHIFT_CREDENTIALS_CONTRACT,
                 SNOWFLAKE_CREDENTIALS_CONTRACT,
                 BIGQUERY_CREDENTIALS_CONTRACT,
+                VERTICA_CREDENTIALS_CONTRACT,
             ],
         },
     },


### PR DESCRIPTION
Changes:
* the dbt profiles.yml file can now accept an `ssl` variable in the connection settings of a vertica type connection. 

This ssl option will enable SSL on the vertica host through vertica_python's connection options with `'ssl': 'enabled'` keyword arg. (similar to the vsql SSLMODE option `-m require`).

---

Here is an example of using the new ssl arg in a vertica connection setup in the profiles.yml (can be seen at the bottom of the image below):
![Screen Shot 2019-07-25 at 7 59 25 AM](https://user-images.githubusercontent.com/2299896/61873523-259e7a00-aeb4-11e9-90fb-296bdb9988b5.png)


---
As a result, the code can now be run on a vertica instance which requires SSL:
![Screen Shot 2019-07-25 at 7 59 03 AM](https://user-images.githubusercontent.com/2299896/61873606-5e3e5380-aeb4-11e9-93ca-eccbfcb20ccd.png)

![Screen Shot 2019-07-25 at 8 00 00 AM2](https://user-images.githubusercontent.com/2299896/61873743-b1b0a180-aeb4-11e9-8320-637d092ad5a5.png)

![Screen Shot 2019-07-25 at 8 00 48 AM](https://user-images.githubusercontent.com/2299896/61873639-6bf3d900-aeb4-11e9-8499-f065638e1e98.png)
